### PR TITLE
Add initial library for singling out and linkability metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # voice-anonymization-legal-eval
+
+A small Python library implementing two privacy metrics for anonymized speech
+embeddings:
+
+- **Singling Out** – probability that a predicate isolates exactly one speaker.
+- **Linkability** – probability that anonymized utterances can be correctly
+  linked to enrollment recordings.
+
+The implementation follows the definitions from *Legally validated evaluation
+framework for voice anonymization*.
+
+## Testing
+
+Tests require `pytest` and `numpy`.
+Run them with:
+
+```bash
+python -m pytest -q
+```
+
+If the dependencies are missing, install them via `pip install numpy pytest`.

--- a/voice_anonymization_metrics/__init__.py
+++ b/voice_anonymization_metrics/__init__.py
@@ -1,0 +1,16 @@
+"""Utilities to evaluate anonymized speech data.
+
+This package provides implementations of the Singling Out and Linkability
+metrics described in ``Legally validated evaluation framework for voice
+anonymization``.  The functions operate on precomputed speaker embeddings.
+"""
+
+from .embeddings import average_embeddings
+from .linkability import linkability_probability
+from .singling_out import singling_out_probability
+
+__all__ = [
+    "average_embeddings",
+    "linkability_probability",
+    "singling_out_probability",
+]

--- a/voice_anonymization_metrics/calibration.py
+++ b/voice_anonymization_metrics/calibration.py
@@ -1,0 +1,33 @@
+"""Calibration utilities for Singling Out metric."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from .utils import cosine_similarity
+
+
+def calibrate_threshold(
+    enroll_vec: ArrayLike,
+    calib_vecs: ArrayLike,
+    target_prob: float,
+) -> float:
+    """Return similarity threshold yielding the desired predicate expectation.
+
+    The function computes cosine similarities between ``enroll_vec`` and
+    ``calib_vecs`` then finds a threshold such that a random calibration score
+    exceeds it with probability close to ``target_prob``.
+    """
+
+    scores = cosine_similarity(calib_vecs, enroll_vec).ravel()
+    scores.sort()
+    scores = scores[::-1]
+    k = int(np.ceil(len(scores) * target_prob))
+    if k <= 0:
+        return 1.0
+    if k >= len(scores):
+        return scores[-1]
+    upper = scores[k - 1]
+    lower = scores[k]
+    return 0.5 * (upper + lower)

--- a/voice_anonymization_metrics/embeddings.py
+++ b/voice_anonymization_metrics/embeddings.py
@@ -1,0 +1,27 @@
+"""Helpers for manipulating speaker embeddings."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def average_embeddings(embeddings: ArrayLike) -> np.ndarray:
+    """Return the average embedding.
+
+    Parameters
+    ----------
+    embeddings:
+        Sequence or array of shape ``(n_samples, n_features)``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Vector of shape ``(n_features,)`` representing the arithmetic mean of
+        the input embeddings.
+    """
+
+    emb = np.asarray(embeddings, dtype=float)
+    if emb.ndim == 1:
+        return emb.copy()
+    return emb.mean(axis=0)

--- a/voice_anonymization_metrics/linkability.py
+++ b/voice_anonymization_metrics/linkability.py
@@ -1,0 +1,29 @@
+"""Implementation of the Linkability metric."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from .utils import cosine_similarity
+
+
+def linkability_probability(test_vecs: ArrayLike, enroll_vecs: ArrayLike) -> float:
+    """Return the probability that test vectors link to the correct speaker.
+
+    Parameters
+    ----------
+    test_vecs:
+        Array of shape ``(n_speakers, n_features)`` containing embeddings for
+        each test speaker.
+    enroll_vecs:
+        Array of shape ``(n_speakers, n_features)`` containing enrollment
+        embeddings for the same speakers in the same order.
+    """
+
+    test = np.asarray(test_vecs)
+    enroll = np.asarray(enroll_vecs)
+    scores = cosine_similarity(test, enroll)
+    best = scores.argmax(axis=1)
+    successes = np.sum(best == np.arange(test.shape[0]))
+    return successes / test.shape[0]

--- a/voice_anonymization_metrics/singling_out.py
+++ b/voice_anonymization_metrics/singling_out.py
@@ -1,0 +1,46 @@
+"""Implementation of the Singling Out metric."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from .calibration import calibrate_threshold
+from .utils import cosine_similarity
+
+
+def singling_out_probability(
+    test_vecs: ArrayLike,
+    enroll_vecs: ArrayLike,
+    calib_vecs: ArrayLike,
+    target_prob: float,
+) -> float:
+    """Compute isolation probability for a set of enrollment speakers.
+
+    Parameters
+    ----------
+    test_vecs:
+        Array of shape ``(n_speakers, n_features)`` with one embedding per
+        speaker in the test subset.
+    enroll_vecs:
+        Array of enrollment embeddings, one per speaker used to build
+        predicates.
+    calib_vecs:
+        Calibration embeddings used to derive thresholds.  They may include
+        multiple embeddings per speaker.
+    target_prob:
+        Desired probability of predicate being true for a random calibration
+        vector.  In the paper this is typically ``1/N`` where ``N`` is the
+        number of speakers under evaluation.
+    """
+
+    test = np.asarray(test_vecs)
+    enroll = np.asarray(enroll_vecs)
+    calib = np.asarray(calib_vecs)
+    successes = 0
+    for e in enroll:
+        thresh = calibrate_threshold(e, calib, target_prob)
+        scores = cosine_similarity(test, e).ravel()
+        if np.sum(scores > thresh) == 1:
+            successes += 1
+    return successes / len(enroll)

--- a/voice_anonymization_metrics/tests/test_linkability.py
+++ b/voice_anonymization_metrics/tests/test_linkability.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from voice_anonymization_metrics.linkability import linkability_probability
+
+
+def test_linkability_perfect():
+    enroll = np.array([[1, 0], [0, 1], [-1, 0]])
+    test = enroll.copy()
+    prob = linkability_probability(test, enroll)
+    assert np.isclose(prob, 1.0)
+
+
+def test_linkability_mismatch():
+    enroll = np.array([[1, 0], [0, 1], [-1, 0]])
+    test = np.array([[0, 1], [1, 0], [-1, 0]])
+    prob = linkability_probability(test, enroll)
+    assert np.isclose(prob, 1 / 3)

--- a/voice_anonymization_metrics/tests/test_singling_out.py
+++ b/voice_anonymization_metrics/tests/test_singling_out.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from voice_anonymization_metrics.singling_out import singling_out_probability
+
+
+def unit_vector_for_similarity(sim):
+    return np.array([sim, np.sqrt(1 - sim ** 2)])
+
+
+def test_singling_out_success():
+    enroll = unit_vector_for_similarity(1.0)
+    calib = np.array([unit_vector_for_similarity(s) for s in [0.95, 0.85, 0.75, 0.65, 0.55]])
+    test = np.array([unit_vector_for_similarity(s) for s in [0.92, 0.8, 0.7, 0.6, 0.5]])
+    prob = singling_out_probability(test, enroll, calib, target_prob=0.2)
+    assert np.isclose(prob, 1.0)
+
+
+def test_singling_out_failure():
+    enroll = unit_vector_for_similarity(1.0)
+    calib = np.array([unit_vector_for_similarity(s) for s in [0.95, 0.85, 0.75, 0.65, 0.55]])
+    # two test vectors exceed the threshold
+    test = np.array([unit_vector_for_similarity(s) for s in [0.92, 0.91, 0.7, 0.6, 0.5]])
+    prob = singling_out_probability(test, enroll, calib, target_prob=0.2)
+    assert np.isclose(prob, 0.0)

--- a/voice_anonymization_metrics/tests/test_utils.py
+++ b/voice_anonymization_metrics/tests/test_utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from voice_anonymization_metrics.utils import cosine_similarity
+
+
+def test_cosine_similarity_basic():
+    a = np.array([1, 0])
+    b = np.array([0, 1])
+    sim = cosine_similarity(a, b)
+    assert sim.shape == (1, 1)
+    assert np.isclose(sim[0, 0], 0.0)
+
+    a2 = np.array([[1, 0], [0, 1]])
+    b2 = np.array([[1, 0], [0, 1]])
+    sim2 = cosine_similarity(a2, b2)
+    assert np.allclose(sim2, np.eye(2))

--- a/voice_anonymization_metrics/utils.py
+++ b/voice_anonymization_metrics/utils.py
@@ -1,0 +1,28 @@
+"""Utility helpers for metric computation."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def cosine_similarity(a: ArrayLike, b: ArrayLike) -> np.ndarray:
+    """Return the cosine similarity matrix between ``a`` and ``b``.
+
+    Parameters
+    ----------
+    a, b:
+        Arrays of shape ``(n_samples, n_features)`` or ``(n_features,)``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Matrix of shape ``(n_a, n_b)`` where ``n_a`` and ``n_b`` are the
+        number of rows in ``a`` and ``b`` respectively.
+    """
+
+    a = np.atleast_2d(np.asarray(a, dtype=float))
+    b = np.atleast_2d(np.asarray(b, dtype=float))
+    a_norm = a / np.linalg.norm(a, axis=1, keepdims=True)
+    b_norm = b / np.linalg.norm(b, axis=1, keepdims=True)
+    return a_norm @ b_norm.T


### PR DESCRIPTION
## Summary
- implement singling out and linkability metrics, plus helper utilities
- add tests demonstrating expected behaviour of both metrics
- document package usage and testing requirements

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6894a3c97d00832c87237b04af3199bc